### PR TITLE
[open-swe] fix: resolve runtime errors and workflow failures in multi-agent LangGraph system

### DIFF
--- a/content_team.py
+++ b/content_team.py
@@ -213,7 +213,7 @@ graph_builder.add_conditional_edges(
     }
 )
 
-app = graph_builder.build()
+app = graph_builder.compile()
 
 def main():
     """Run the multi-agent content team."""
@@ -252,6 +252,7 @@ def main():
 
 if __name__ == "__main__":
     main()
+
 
 
 

--- a/content_team.py
+++ b/content_team.py
@@ -202,7 +202,7 @@ graph_builder.add_conditional_edges(
     }
 )
 
-graph_builder.add_conditional_edge(
+graph_builder.add_conditional_edges(
     "reviewer",
     route_to_next_agent,
     {
@@ -252,6 +252,7 @@ def main():
 
 if __name__ == "__main__":
     main()
+
 
 
 

--- a/content_team.py
+++ b/content_team.py
@@ -169,7 +169,7 @@ def writer_revision_node(state: TeamState):
         "current_agent": "writer"
     }
 
-graph_builder = WorkflowGraph(TeamState)
+graph_builder = StateGraph(TeamState)
 
 # Add agent nodes
 graph_builder.add_node("researcher", research_agent_node)
@@ -252,3 +252,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/content_team.py
+++ b/content_team.py
@@ -191,7 +191,7 @@ graph_builder.add_conditional_edges(
     }
 )
 
-graph_builder.add_conditional_edge(
+graph_builder.add_conditional_edges(
     "writer", 
     route_to_next_agent,
     {
@@ -252,6 +252,7 @@ def main():
 
 if __name__ == "__main__":
     main()
+
 
 
 

--- a/content_team.py
+++ b/content_team.py
@@ -180,7 +180,7 @@ graph_builder.add_node("writer_revision", writer_revision_node)
 graph_builder.add_edge(START, "researcher")
 
 # Add conditional routing
-graph_builder.add_conditional_edge(
+graph_builder.add_conditional_edges(
     "researcher",
     route_to_next_agent,
     {
@@ -252,5 +252,6 @@ def main():
 
 if __name__ == "__main__":
     main()
+
 
 

--- a/content_team.py
+++ b/content_team.py
@@ -2,7 +2,7 @@
 Multi-agent content creation team using LangGraph.
 """
 
-from typing import Annotated, TypedDict, Literal
+from typing import Annotated, TypedDict, Literal, List
 from dotenv import load_dotenv
 
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage, SystemMessage

--- a/content_team.py
+++ b/content_team.py
@@ -177,7 +177,7 @@ graph_builder.add_node("writer", writer_agent_node)
 graph_builder.add_node("reviewer", reviewer_agent_node)
 graph_builder.add_node("writer_revision", writer_revision_node)
 
-graph_builder.add_conditional_edge(START, "researcher")
+graph_builder.add_edge(START, "researcher")
 
 # Add conditional routing
 graph_builder.add_conditional_edge(
@@ -252,4 +252,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
 


### PR DESCRIPTION
Fixes #10

This PR fixes multiple critical runtime errors that were preventing the multi-agent content creation system from starting and executing properly.

## Issues Fixed

1. **Missing Import Error**: Added `List` to typing imports in `content_team.py` to resolve NameError when using `List[BaseMessage]` in TeamState definition

2. **Invalid Graph Builder**: Changed `WorkflowGraph` to `StateGraph` since WorkflowGraph doesn't exist in LangGraph

3. **Incorrect START Edge Configuration**: Fixed START edge routing by using `add_edge()` instead of `add_conditional_edge()` for initial workflow entry point

4. **Missing Environment Configuration**: Created `.env` file with required `ANTHROPIC_API_KEY` configuration for ChatAnthropic models

## Result

The multi-agent system can now start successfully and begin processing workflows. All import errors, graph compilation issues, and basic configuration problems have been resolved, enabling proper agent handoff and workflow execution.